### PR TITLE
add OpenBSD support

### DIFF
--- a/scanner/CMakeLists.txt
+++ b/scanner/CMakeLists.txt
@@ -28,8 +28,15 @@ find_package(Threads REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(deps REQUIRED IMPORTED_TARGET pugixml)
 
+find_library(librt rt)
+if("${librt}" MATCHES "librt-NOTFOUND")
+  unset(LIBRT)
+else()
+  set(LIBRT rt)
+endif()
+
 add_executable(hyprwire-scanner main.cpp)
-target_link_libraries(hyprwire-scanner PRIVATE rt Threads::Threads
+target_link_libraries(hyprwire-scanner PRIVATE ${LIBRT} Threads::Threads
                                                PkgConfig::deps)
 
 target_include_directories(hyprwire-scanner

--- a/src/core/server/ServerClient.cpp
+++ b/src/core/server/ServerClient.cpp
@@ -31,7 +31,11 @@ void CServerClient::dispatchFirstPoll() {
 
     // get peer's pid
 
+#if defined(__OpenBSD__)
+    struct sockpeercred cred;
+#else
     ucred     cred;
+#endif
     socklen_t len = sizeof(cred);
 
     if (getsockopt(m_fd.get(), SOL_SOCKET, SO_PEERCRED, &cred, &len) == -1) {

--- a/src/core/server/ServerSocket.cpp
+++ b/src/core/server/ServerSocket.cpp
@@ -12,6 +12,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netinet/in.h>
+#include <unistd.h>
 
 #include <filesystem>
 #include <hyprutils/utils/ScopeGuard.hpp>

--- a/tests/Client.cpp
+++ b/tests/Client.cpp
@@ -1,6 +1,7 @@
 #include <hyprwire/hyprwire.hpp>
 #include <print>
 #include "generated/test_protocol_v1-client.hpp"
+#include <unistd.h>
 
 using namespace Hyprutils::Memory;
 

--- a/tests/Server.cpp
+++ b/tests/Server.cpp
@@ -1,6 +1,7 @@
 #include <hyprwire/hyprwire.hpp>
 #include <print>
 #include <sys/signal.h>
+#include <unistd.h>
 
 #include "generated/test_protocol_v1-server.hpp"
 


### PR DESCRIPTION
Three fixes are required:

- no librt support
- use `struct sockpeercred` instead of `cred`
- add `#include <unstd.h>` to use read(), write() and pipe()