### PR TITLE
Include string_view header

### DIFF
--- a/include/hyprwire/core/implementation/Object.hpp
+++ b/include/hyprwire/core/implementation/Object.hpp
@@ -2,6 +2,7 @@
 
 #include <hyprutils/memory/SharedPtr.hpp>
 #include <functional>
+#include <string_view>
 
 namespace Hyprwire {
     class IServerClient;

--- a/scanner/main.cpp
+++ b/scanner/main.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <ranges>
 #include <algorithm>
+#include <string_view>
 
 #include <pugixml.hpp>
 

--- a/src/core/implementation/Object.cpp
+++ b/src/core/implementation/Object.cpp
@@ -1,3 +1,4 @@
+#include <string_view>
 #include <hyprwire/core/implementation/ClientImpl.hpp>
 #include <hyprwire/core/implementation/Spec.hpp>
 #include <hyprwire/core/implementation/ServerImpl.hpp>

--- a/src/core/message/messages/BindProtocol.cpp
+++ b/src/core/message/messages/BindProtocol.cpp
@@ -4,6 +4,7 @@
 #include "../../../helpers/Env.hpp"
 
 #include <stdexcept>
+#include <string_view>
 #include <hyprwire/core/types/MessageMagic.hpp>
 
 using namespace Hyprwire;

--- a/src/core/message/messages/FatalProtocolError.cpp
+++ b/src/core/message/messages/FatalProtocolError.cpp
@@ -5,6 +5,7 @@
 #include "../../../helpers/Env.hpp"
 
 #include <stdexcept>
+#include <string_view>
 #include <hyprwire/core/types/MessageMagic.hpp>
 
 using namespace Hyprwire;

--- a/src/core/message/messages/HandshakeProtocols.cpp
+++ b/src/core/message/messages/HandshakeProtocols.cpp
@@ -4,6 +4,7 @@
 #include "../../../helpers/Env.hpp"
 
 #include <stdexcept>
+#include <string_view>
 #include <hyprwire/core/types/MessageMagic.hpp>
 
 using namespace Hyprwire;

--- a/src/core/server/ServerObject.cpp
+++ b/src/core/server/ServerObject.cpp
@@ -11,6 +11,7 @@
 
 #include <cstdarg>
 #include <cstring>
+#include <string_view>
 #include <ffi.h>
 
 using namespace Hyprwire;

--- a/src/core/wireObject/IWireObject.cpp
+++ b/src/core/wireObject/IWireObject.cpp
@@ -12,6 +12,7 @@
 
 #include <cstdarg>
 #include <cstring>
+#include <string_view>
 #include <ffi.h>
 
 using namespace Hyprwire;


### PR DESCRIPTION
Fixes https://github.com/hyprwm/hyprwire/issues/8
I am on Gentoo LLVM profile, was bringing hyprwire into a local portage overlay and saw it failed to compile.

