### PR TITLE
core/message: Fix uninitialized global pointer

### DIFF
--- a/src/core/message/MessageParser.hpp
+++ b/src/core/message/MessageParser.hpp
@@ -33,5 +33,5 @@ namespace Hyprwire {
         size_t parseSingleMessage(SSocketRawParsedMessage& data, size_t off, SP<CClientSocket> client);
     };
 
-    inline UP<CMessageParser> g_messageParser;
+    inline UP<CMessageParser> g_messageParser = makeUnique<CMessageParser>();
 };


### PR DESCRIPTION
g_messageParser referenced as an uninitialized global pointer. (This happened to work in some builds despite being undefined behavior.) Instead, g_messageParser now is a global struct, not a unique_ptr.

See https://github.com/hyprwm/hyprwire/issues/11.