### PR TITLE
core: Fix serialization bug with unaligned pointer reads

### DIFF
--- a/src/core/message/messages/BindProtocol.cpp
+++ b/src/core/message/messages/BindProtocol.cpp
@@ -3,6 +3,7 @@
 #include "../MessageParser.hpp"
 #include "../../../helpers/Env.hpp"
 
+#include <cstring>
 #include <stdexcept>
 #include <string_view>
 #include <hyprwire/core/types/MessageMagic.hpp>
@@ -19,7 +20,7 @@ CBindProtocolMessage::CBindProtocolMessage(const std::vector<uint8_t>& data, siz
         if (data.at(offset + 1) != HW_MESSAGE_MAGIC_TYPE_UINT)
             return;
 
-        m_seq = *rc<const uint32_t*>(&data.at(offset + 2));
+        std::memcpy(&m_seq, &data.at(offset + 2), sizeof(m_seq));
 
         if (data.at(offset + 6) != HW_MESSAGE_MAGIC_TYPE_VARCHAR)
             return;
@@ -37,7 +38,7 @@ CBindProtocolMessage::CBindProtocolMessage(const std::vector<uint8_t>& data, siz
         if (data.at(offset + needle) != HW_MESSAGE_MAGIC_TYPE_UINT)
             return;
 
-        m_version = *rc<const uint32_t*>(&data.at(offset + needle + 1));
+        std::memcpy(&m_version, &data.at(offset + needle + 1), sizeof(m_version));
 
         if (!m_version)
             return;
@@ -62,7 +63,7 @@ CBindProtocolMessage::CBindProtocolMessage(const std::string& protocol, uint32_t
         HW_MESSAGE_TYPE_BIND_PROTOCOL, HW_MESSAGE_MAGIC_TYPE_UINT, 0, 0, 0, 0,
     };
 
-    *rc<uint32_t*>(&m_data[2]) = seq;
+    std::memcpy(&m_data[2], &seq, sizeof(seq));
 
     m_data.emplace_back(HW_MESSAGE_MAGIC_TYPE_VARCHAR);
 
@@ -71,7 +72,7 @@ CBindProtocolMessage::CBindProtocolMessage(const std::string& protocol, uint32_t
 
     m_data.append_range(std::vector<uint8_t>{HW_MESSAGE_MAGIC_TYPE_UINT, 0, 0, 0, 0});
 
-    *rc<uint32_t*>(&m_data[m_data.size() - 4]) = version;
+    std::memcpy(&m_data[m_data.size() - 4], &version, sizeof(version));
 
     m_data.emplace_back(HW_MESSAGE_MAGIC_END);
 }

--- a/src/core/message/messages/GenericProtocolMessage.cpp
+++ b/src/core/message/messages/GenericProtocolMessage.cpp
@@ -4,6 +4,7 @@
 #include "../../../helpers/Env.hpp"
 #include "../../../helpers/Log.hpp"
 
+#include <cstring>
 #include <stdexcept>
 #include <hyprwire/core/types/MessageMagic.hpp>
 
@@ -19,12 +20,12 @@ CGenericProtocolMessage::CGenericProtocolMessage(const std::vector<uint8_t>& dat
         if (data.at(offset + 1) != HW_MESSAGE_MAGIC_TYPE_OBJECT)
             return;
 
-        m_object = *rc<const uint32_t*>(&data.at(offset + 2));
+        std::memcpy(&m_object, &data.at(offset + 2), sizeof(m_object));
 
         if (data.at(offset + 6) != HW_MESSAGE_MAGIC_TYPE_UINT)
             return;
 
-        m_method = *rc<const uint32_t*>(&data.at(offset + 7));
+        std::memcpy(&m_method, &data.at(offset + 7), sizeof(m_method));
 
         size_t i = 11;
         while (data.at(offset + i) != HW_MESSAGE_MAGIC_END) {

--- a/src/core/message/messages/HandshakeAck.cpp
+++ b/src/core/message/messages/HandshakeAck.cpp
@@ -3,6 +3,7 @@
 #include "../MessageParser.hpp"
 #include "../../../helpers/Env.hpp"
 
+#include <cstring>
 #include <stdexcept>
 #include <hyprwire/core/types/MessageMagic.hpp>
 
@@ -23,7 +24,7 @@ CHandshakeAckMessage::CHandshakeAckMessage(const std::vector<uint8_t>& data, siz
         if (data.at(offset + needle + 4) != HW_MESSAGE_MAGIC_END)
             return;
 
-        m_version = *rc<const uint32_t*>(&data.at(offset + needle));
+        std::memcpy(&m_version, &data.at(offset + needle), sizeof(m_version));
 
         needle += 4;
 
@@ -46,7 +47,7 @@ CHandshakeAckMessage::CHandshakeAckMessage(uint32_t version) {
 
     m_data.resize(6);
 
-    *rc<uint32_t*>(&m_data[2]) = version;
+    std::memcpy(&m_data[2], &version, sizeof(version));
 
     m_data.emplace_back(HW_MESSAGE_MAGIC_END);
 }

--- a/src/core/message/messages/NewObject.cpp
+++ b/src/core/message/messages/NewObject.cpp
@@ -3,6 +3,7 @@
 #include "../MessageParser.hpp"
 #include "../../../helpers/Env.hpp"
 
+#include <cstring>
 #include <stdexcept>
 #include <hyprwire/core/types/MessageMagic.hpp>
 
@@ -18,12 +19,12 @@ CNewObjectMessage::CNewObjectMessage(const std::vector<uint8_t>& data, size_t of
         if (data.at(offset + 1) != HW_MESSAGE_MAGIC_TYPE_UINT)
             return;
 
-        m_id = *rc<const uint32_t*>(&data.at(offset + 2));
+        std::memcpy(&m_id, &data.at(offset + 2), sizeof(m_id));
 
         if (data.at(offset + 6) != HW_MESSAGE_MAGIC_TYPE_UINT)
             return;
 
-        m_seq = *rc<const uint32_t*>(&data.at(offset + 7));
+        std::memcpy(&m_seq, &data.at(offset + 7), sizeof(m_seq));
 
         if (data.at(offset + 11) != HW_MESSAGE_MAGIC_END)
             return;
@@ -43,6 +44,6 @@ CNewObjectMessage::CNewObjectMessage(uint32_t seq, uint32_t id) {
         HW_MESSAGE_TYPE_NEW_OBJECT, HW_MESSAGE_MAGIC_TYPE_UINT, 0, 0, 0, 0, HW_MESSAGE_MAGIC_TYPE_UINT, 0, 0, 0, 0, HW_MESSAGE_MAGIC_END,
     };
 
-    *rc<uint32_t*>(&m_data[2]) = seq;
-    *rc<uint32_t*>(&m_data[7]) = seq;
+    std::memcpy(&m_data[2], &seq, sizeof(seq));
+    std::memcpy(&m_data[7], &seq, sizeof(seq));
 }


### PR DESCRIPTION
The serialization/deserialization code used to use reinterpret_casts to read/write data types to the byte buffer. When the pointers are unaligned, this is undefined behavior. This changes those operations to use std::memcpy.

See https://github.com/hyprwm/hyprwire/issues/11.