### PR TITLE
GenericProtocolMessage: write full object id in resolveSeq

### DIFF
--- a/src/core/message/messages/GenericProtocolMessage.cpp
+++ b/src/core/message/messages/GenericProtocolMessage.cpp
@@ -123,6 +123,6 @@ const std::vector<int>& CGenericProtocolMessage::fds() const {
 
 void CGenericProtocolMessage::resolveSeq(uint32_t id) {
     m_object = id;
-    if (m_data.size() > 2)
-        m_data[2] = id;
+    if (m_data.size() >= 6)
+        std::memcpy(m_data.data() + 2, &id, sizeof(uint32_t));
 }


### PR DESCRIPTION
`resolveSeq` updates only the first byte of the 32-bit object id stored in the serialized message. 
The id is later decoded via memcpy into a uint32_t, so partially updating the field produces endianness-dependent values(id 2 becoming 33554432) breaking dispatch on big-endian systems.

failure on s390x:
```
1: Test command: /tmp/autopkgtest.TWXHjF/autopkgtest_tmp/test-runner
1: Working Directory: /tmp/autopkgtest.TWXHjF/autopkgtest_tmp/build
1: Test timeout computed to be: 10000000
1: [client] test protocol supported at version 1. Binding.
1: [client] Bound!
1: [client] Will send fd 5
1: [client] Server says Hello manager
1: [client] Sent hello!
1: [client] Server says on object Hello object
1: Client exited on its own (correct behavior).
1: ===== DEBUG: client.log =====
1: test protocol supported at version 1. Binding.$
1: Bound!$
1: Will send fd 5$
1: Server says Hello manager$
1: Sent hello!$
1: Server says on object Hello object$
1: =============================
1: ===== DEBUG: server.log =====
1: Object bound XD$
1: Recvd message: Hello!$
1: Recvd fd 8 with data: pipe!$
1: Received 2 fds$
1: fd 9 with data: o kurwa$
1: fd 10 with data: bober!!$
1: Got array message: "Hello, via, array!"$
1: Got array message: ""$
1: Got uint array message: "69, 420, 2137"$
1: [hw] warn: [7 @ 1059.963] -> Generic message not handled. No object with id 33554432!$
1: [hw] warn: [7 @ 1062.275] -> Generic message not handled. No object with id 33554432!$
1: =============================
1: Checking client.log for 'test protocol supported at version 1. Binding.'... Pass
1: Checking client.log for 'Bound!'... Pass
1: Checking client.log for 'Sent hello!'... Pass
1: Checking client.log for '[hw] err: fatal protocol error: object 2 error 1: Important error occurred!'... Fail
1/1 Test #1: test .............................***Failed    8.33 sec

```