### PR TITLE
macros: fix typo

### DIFF
--- a/src/Macros.hpp
+++ b/src/Macros.hpp
@@ -32,7 +32,7 @@ inline float steadyMillis() {
 
 #define ASSERT(expr) RASSERT(expr, "?")
 
-#ifndef HYPRTWIRE_DEBUG
+#ifndef HYPRWIRE_DEBUG
 
 #define UNREACHABLE() std::unreachable();
 


### PR DESCRIPTION
also every editor I tried is inserting newline at the end of file