### PR TITLE
fix: include <cstring> for strcopy() in ClientSocket.cpp

### DIFF
--- a/src/core/client/ClientSocket.cpp
+++ b/src/core/client/ClientSocket.cpp
@@ -21,6 +21,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netinet/in.h>
+#include <cstring>
 
 #include <filesystem>
 #include <hyprutils/utils/ScopeGuard.hpp>


### PR DESCRIPTION
Hello, 
Hyprwire 0.3.0 does not build, and the same issue affects the main branch (4e1933).

ClientSocket.cpp seems to be missing an import:
`ClientSocket.cpp:63:5: error: 'strcpy' was not declared in this scope`

When the missing import is added, I'm able to build Hyprwire without further errors.

Best Regards,