### PR TITLE
core: set needsPollRecheck on client error

### DIFF
--- a/src/core/server/ServerSocket.cpp
+++ b/src/core/server/ServerSocket.cpp
@@ -302,8 +302,10 @@ bool CServerSocket::dispatchExistingConnections() {
             continue;
         }
 
-        if (m_clients.at(i - internalFds())->m_error)
+        if (m_clients.at(i - internalFds())->m_error) {
+            needsPollRecheck = true;
             TRACE(Debug::log(TRACE, "[{} @ {:.3f}] Dropping client (protocol error)", m_clients.at(i - internalFds())->m_fd.get(), steadyMillis()));
+        }
     }
 
     if (needsPollRecheck) {


### PR DESCRIPTION
fix cleanup for clients that hit a protocol error, errored clients were left in m_clients and m_pollfds until a later poll recheck