### PR TITLE
core/client: Adapt orphan cleanup.

### DIFF
--- a/src/core/client/ClientSocket.cpp
+++ b/src/core/client/ClientSocket.cpp
@@ -382,6 +382,9 @@ void CClientSocket::collectOrphanedObjects() {
         if (obj->m_id == 0)
             return false;
 
+        if (obj->getData() || !obj->m_listeners.empty())
+            return false;
+
         return obj.strongRef() == 1;
     });
 }


### PR DESCRIPTION
As mentioned on discord, the commit https://github.com/hyprwm/hyprwire/commit/3645706cf39f3993d936de341121ed70c46698fc breaks the --dmenu menu option in hyprlauncher. It looks like hyprwire orphan cleanup is too aggressive.

See discussion [here](https://discord.com/channels/961691461554950145/1434567675152961655/1495448000862883881).

Edit: I checked hat the mentioned commit introduced the issue, but I am no sure if this is the desired fix.