### PR TITLE
Add FreeBSD support for peer process identification

### DIFF
--- a/src/core/server/ServerClient.cpp
+++ b/src/core/server/ServerClient.cpp
@@ -15,6 +15,11 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
+#if defined(__FreeBSD__)
+#include <sys/ucred.h>
+#include <sys/un.h>
+#endif
+
 using namespace Hyprwire;
 
 CServerClient::CServerClient(int fd) : m_fd(fd) {
@@ -37,19 +42,29 @@ void CServerClient::dispatchFirstPoll() {
 
     // get peer's pid
 
-#if defined(__OpenBSD__)
+#if defined(__FreeBSD__)
+    struct xucred cred;
+#elif defined(__OpenBSD__)
     struct sockpeercred cred;
 #else
     ucred cred;
 #endif
     socklen_t len = sizeof(cred);
 
+#if defined(__FreeBSD__)
+    if (getsockopt(m_fd.get(), SOL_SOCKET, LOCAL_PEERCRED, &cred, &len) == -1) {
+#else
     if (getsockopt(m_fd.get(), SOL_SOCKET, SO_PEERCRED, &cred, &len) == -1) {
+#endif
         TRACE(Debug::log(TRACE, "dispatchFirstPoll: failed to get pid"));
         return;
     }
 
+#if defined(__FreeBSD__)
+    m_pid = cred.cr_pid;
+#else
     m_pid = cred.pid;
+#endif
 }
 
 void CServerClient::sendMessage(const IMessage& message) {

--- a/tests/Fork.cpp
+++ b/tests/Fork.cpp
@@ -3,6 +3,7 @@
 #include <sys/poll.h>
 #include <sys/signal.h>
 #include <sys/socket.h>
+#include <unistd.h>
 
 #include "generated/test_protocol_v1-server.hpp"
 #include "generated/test_protocol_v1-client.hpp"


### PR DESCRIPTION
This PR enables `CServerClient` to correctly retrieve the peer's PID on FreeBSD.

`SO_PEERCRED` is not available on FreeBSD. Instead, it uses `LOCAL_PEERCRED` with `struct xucred` to obtain socket peer credentials. The changes include:

- Includes necessary headers (`<sys/ucred.h>` and `<sys/un.h>`)
- Implements the credential retrieval logic using `LOCAL_PEERCRED`
- Correctly maps `cr_pid` to `m_pid`

Also this PR adds a missing include in `tests/Fork.cpp`.