### PR TITLE
client: read pending data before handling POLLHUP

### DIFF
--- a/src/core/client/ClientSocket.cpp
+++ b/src/core/client/ClientSocket.cpp
@@ -144,12 +144,9 @@ bool CClientSocket::dispatchEvents(bool block) {
     if (m_handshakeDone)
         Syscalls::poll(m_pollfds.data(), m_pollfds.size(), block ? -1 : 0);
 
-    if (m_pollfds[0].revents & POLLHUP)
-        return false;
-
     if (!(m_pollfds[0].revents & POLLIN)) {
         collectOrphanedObjects();
-        return true;
+        return !(m_pollfds[0].revents & POLLHUP);
     }
 
     // dispatch


### PR DESCRIPTION
When the server sends a fatal protocol error and immediately closes the
connection, poll(2) can return with both POLLHUP and POLLIN set
simultaneously. Previously POLLHUP was checked first, causing the client
to return early without reading the pending data off the socket.

This was observed as a flaky autopkgtest failure on slower architectures
(ppc64el) where the server's fatal error message and connection close
arrive in the same poll cycle, while on faster hardware (amd64) they
typically arrive in separate cycles masking the bug.

good: https://ci.debian.net/packages/h/hyprwire/testing/amd64/70722966/
bad: https://ci.debian.net/packages/h/hyprwire/testing/ppc64el/70910866/